### PR TITLE
Add stock viewer and detailed help

### DIFF
--- a/bot/database/methods/read.py
+++ b/bot/database/methods/read.py
@@ -162,6 +162,15 @@ def get_item_value(item_name: str) -> dict | None:
     return result.__dict__ if result else None
 
 
+def get_item_values(item_name: str):
+    return Database().session.query(ItemValues).filter(ItemValues.item_name == item_name).all()
+
+
+def get_item_value_by_id(value_id: int) -> dict | None:
+    result = Database().session.query(ItemValues).filter(ItemValues.id == value_id).first()
+    return result.__dict__ if result else None
+
+
 def select_item_values_amount(item_name: str) -> int:
     return Database().session.query(func.count()).filter(ItemValues.item_name == item_name).scalar()
 

--- a/bot/handlers/admin/main.py
+++ b/bot/handlers/admin/main.py
@@ -1,15 +1,17 @@
 from aiogram import Dispatcher
 from aiogram.types import CallbackQuery
 
-from bot.keyboards import console
-from bot.database.methods import check_role
+from bot.keyboards import console, back
+from bot.database.methods import check_role, get_user_language
 from bot.database.models import Permission
+from bot.localization import t
 from bot.misc import TgConfig
 
 from bot.handlers.admin.broadcast import register_mailing
 from bot.handlers.admin.shop_management_states import register_shop_management
 from bot.handlers.admin.user_management_states import register_user_management
 from bot.handlers.admin.assistant_management_states import register_assistant_management
+from bot.handlers.admin.view_stock import register_view_stock
 from bot.handlers.other import get_bot_user_ids
 
 
@@ -26,11 +28,29 @@ async def console_callback_handler(call: CallbackQuery):
     await call.answer('Insufficient rights')
 
 
+async def admin_help_callback_handler(call: CallbackQuery):
+    bot, user_id = await get_bot_user_ids(call)
+    TgConfig.STATE[user_id] = None
+    role = check_role(user_id)
+    user_lang = get_user_language(user_id) or 'en'
+    assistant_role = Permission.USE | Permission.ASSIGN_PHOTOS
+    key = 'assistant_help_info' if role == assistant_role else 'admin_help_info'
+    text = t(user_lang, key)
+    await bot.edit_message_text(text,
+                                chat_id=call.message.chat.id,
+                                message_id=call.message.message_id,
+                                reply_markup=back('console'))
+
+
 def register_admin_handlers(dp: Dispatcher) -> None:
     dp.register_callback_query_handler(console_callback_handler,
                                        lambda c: c.data == 'console')
+    dp.register_callback_query_handler(admin_help_callback_handler,
+                                       lambda c: c.data == 'admin_help',
+                                       state='*')
 
     register_mailing(dp)
     register_shop_management(dp)
     register_user_management(dp)
     register_assistant_management(dp)
+    register_view_stock(dp)

--- a/bot/handlers/admin/view_stock.py
+++ b/bot/handlers/admin/view_stock.py
@@ -1,0 +1,160 @@
+import os
+from aiogram import Dispatcher
+from aiogram.types import CallbackQuery
+
+from bot.database.methods import (
+    check_role,
+    get_all_category_names,
+    get_all_subcategories,
+    get_all_item_names,
+    get_category_parent,
+    get_item_values,
+    get_item_value_by_id,
+    buy_item,
+)
+from bot.database.models import Permission
+from bot.handlers.other import get_bot_user_ids
+from bot.keyboards import (
+    stock_categories_list,
+    stock_goods_list,
+    stock_values_list,
+    stock_value_actions,
+)
+from bot.misc import TgConfig
+from bot.utils import display_name
+
+
+async def view_stock_callback_handler(call: CallbackQuery):
+    bot, user_id = await get_bot_user_ids(call)
+    TgConfig.STATE[user_id] = None
+    role = check_role(user_id)
+    if role & Permission.OWN:
+        categories = get_all_category_names()
+        await bot.edit_message_text(
+            '📦 Choose category',
+            chat_id=call.message.chat.id,
+            message_id=call.message.message_id,
+            reply_markup=stock_categories_list(categories, None),
+        )
+        return
+    await call.answer('Insufficient rights')
+
+
+async def view_stock_category_handler(call: CallbackQuery):
+    bot, user_id = await get_bot_user_ids(call)
+    role = check_role(user_id)
+    if not role & Permission.OWN:
+        await call.answer('Insufficient rights')
+        return
+    category = call.data.split(':', 1)[1]
+    subs = get_all_subcategories(category)
+    if subs:
+        parent = get_category_parent(category)
+        await bot.edit_message_text(
+            '📂 Choose category',
+            chat_id=call.message.chat.id,
+            message_id=call.message.message_id,
+            reply_markup=stock_categories_list(subs, parent),
+        )
+        return
+    items = get_all_item_names(category)
+    if items:
+        await bot.edit_message_text(
+            '🏷 Choose item',
+            chat_id=call.message.chat.id,
+            message_id=call.message.message_id,
+            reply_markup=stock_goods_list(items, category),
+        )
+        return
+    await call.answer('No items')
+
+
+async def view_stock_item_handler(call: CallbackQuery):
+    bot, user_id = await get_bot_user_ids(call)
+    role = check_role(user_id)
+    if not role & Permission.OWN:
+        await call.answer('Insufficient rights')
+        return
+    _, item_name, category = call.data.split(':', 2)
+    values = get_item_values(item_name)
+    if values:
+        await bot.edit_message_text(
+            f'📦 Stock for {display_name(item_name)}',
+            chat_id=call.message.chat.id,
+            message_id=call.message.message_id,
+            reply_markup=stock_values_list(values, item_name, category),
+        )
+        return
+    await call.answer('No stock')
+
+
+async def view_stock_value_handler(call: CallbackQuery):
+    bot, user_id = await get_bot_user_ids(call)
+    role = check_role(user_id)
+    if not role & Permission.OWN:
+        await call.answer('Insufficient rights')
+        return
+    _, value_id, item_name, category = call.data.split(':', 3)
+    value_id = int(value_id)
+    value = get_item_value_by_id(value_id)
+    if not value:
+        await call.answer('Not found')
+        return
+    if value['value'] and os.path.isfile(value['value']):
+        with open(value['value'], 'rb') as doc:
+            await bot.send_document(user_id, doc)
+    else:
+        await bot.send_message(user_id, value['value'])
+    await bot.edit_message_text(
+        f'ID {value_id}',
+        chat_id=call.message.chat.id,
+        message_id=call.message.message_id,
+        reply_markup=stock_value_actions(value_id, item_name, category),
+    )
+
+
+async def view_stock_delete_handler(call: CallbackQuery):
+    bot, user_id = await get_bot_user_ids(call)
+    role = check_role(user_id)
+    if not role & Permission.OWN:
+        await call.answer('Insufficient rights')
+        return
+    _, value_id, item_name, category = call.data.split(':', 3)
+    value_id = int(value_id)
+    value = get_item_value_by_id(value_id)
+    if value and value['value'] and os.path.isfile(value['value']):
+        os.remove(value['value'])
+    buy_item(value_id)
+    values = get_item_values(item_name)
+    await bot.edit_message_text(
+        '✅ Stock deleted',
+        chat_id=call.message.chat.id,
+        message_id=call.message.message_id,
+        reply_markup=stock_values_list(values, item_name, category),
+    )
+
+
+def register_view_stock(dp: Dispatcher) -> None:
+    dp.register_callback_query_handler(
+        view_stock_callback_handler, lambda c: c.data == 'view_stock'
+    )
+    dp.register_callback_query_handler(
+        view_stock_category_handler,
+        lambda c: c.data.startswith('stock_cat:'),
+        state='*',
+    )
+    dp.register_callback_query_handler(
+        view_stock_item_handler,
+        lambda c: c.data.startswith('stock_item:'),
+        state='*',
+    )
+    dp.register_callback_query_handler(
+        view_stock_value_handler,
+        lambda c: c.data.startswith('stock_val:'),
+        state='*',
+    )
+    dp.register_callback_query_handler(
+        view_stock_delete_handler,
+        lambda c: c.data.startswith('stock_del:'),
+        state='*',
+    )

--- a/bot/handlers/user/main.py
+++ b/bot/handlers/user/main.py
@@ -1166,7 +1166,8 @@ def register_user_handlers(dp: Dispatcher):
     dp.register_callback_query_handler(bought_items_callback_handler,
                                        lambda c: c.data == 'bought_items')
     dp.register_callback_query_handler(back_to_menu_callback_handler,
-                                       lambda c: c.data == 'back_to_menu')
+                                       lambda c: c.data == 'back_to_menu',
+                                       state='*')
     dp.register_callback_query_handler(close_callback_handler,
                                        lambda c: c.data == 'close')
     dp.register_callback_query_handler(change_language,

--- a/bot/localization.py
+++ b/bot/localization.py
@@ -12,12 +12,27 @@ LANGUAGES = {
         'admin_panel': '🎛 Admin Panel',
         'help': '❓ Help',
         'help_info': (
-            'Use the main menu buttons to navigate through the bot:\n'
-            '🛍 Shop – browse products.\n'
-            '👤 Profile – view your balance and purchases.\n'
-            '💸 Top Up – add funds to your balance.\n'
+            'Use the main menu to work with the bot:\n'
+            '🛍 Shop – browse categories and choose a product.\n'
+            '   • Select an item and confirm to purchase it.\n'
+            '👤 Profile – view your balance and purchased items.\n'
+            '💸 Top Up – choose a payment method and follow the instructions to add funds.\n'
             '🌐 Language – switch the interface language.\n'
+            '🎁 Purchased items – available in Profile after you buy something.\n'
             'If you need assistance, contact {helper}.'
+        ),
+        'admin_help_info': (
+            'Admin panel functions:\n'
+            '🛠 Assign assistants – manage assistant accounts.\n'
+            '📦 View Stock – browse and delete available product stock.\n'
+            '🏪 Parduotuvės valdymas – manage shop categories and items.\n'
+            '👥 Vartotojų valdymas – manage user balances and roles.\n'
+            '📢 Pranešimų siuntimas – send messages to all users.'
+        ),
+        'assistant_help_info': (
+            'Assistant panel functions:\n'
+            '🖼 Assign photos – attach photos to items.\n'
+            'Use Back to menu to return.'
         ),
         'choose_language': 'Please choose a language',
         'invoice_message': (
@@ -68,12 +83,27 @@ LANGUAGES = {
         'admin_panel': '🎛 Админ панель',
         'help': '❓ Помощь',
         'help_info': (
-            'Используйте кнопки главного меню для навигации по боту:\n'
-            '🛍 Магазин – просмотр товаров.\n'
-            '👤 Профиль – ваш баланс и покупки.\n'
-            '💸 Пополнить – добавить средства на баланс.\n'
+            'Используйте главное меню для работы с ботом:\n'
+            '🛍 Магазин – просматривайте категории и выбирайте товар.\n'
+            '   • Выберите товар и подтвердите покупку.\n'
+            '👤 Профиль – ваш баланс и купленные товары.\n'
+            '💸 Пополнить – выберите способ оплаты и следуйте инструкциям.\n'
             '🌐 Язык – сменить язык интерфейса.\n'
+            '🎁 Купленные товары – доступны в профиле после покупки.\n'
             'Если нужна помощь, обратитесь к {helper}.'
+        ),
+        'admin_help_info': (
+            'Функции админ-панели:\n'
+            '🛠 Назначить ассистентов – управление помощниками.\n'
+            '📦 Просмотр склада – список товаров и удаление остатков.\n'
+            '🏪 Parduotuvės valdymas – управление магазином.\n'
+            '👥 Vartotojų valdymas – управление пользователями.\n'
+            '📢 Pranešimų siuntimas – рассылка сообщений.'
+        ),
+        'assistant_help_info': (
+            'Функции панели ассистента:\n'
+            '🖼 Привязать фото – добавление фотографий к товарам.\n'
+            'Используйте "Назад в меню" для возврата.'
         ),
         'choose_language': 'Пожалуйста, выберите язык',
         'invoice_message': (
@@ -123,12 +153,27 @@ LANGUAGES = {
         'admin_panel': '🎛 Admin pultas',
         'help': '❓ Pagalba',
         'help_info': (
-            'Naudokite pagrindinio meniu mygtukus, kad naršytumėte botą:\n'
-            '🛍 Parduotuvė – peržiūrėti prekes.\n'
-            '👤 Profilis – matyti balansą ir pirkinius.\n'
-            '💸 Papildyti – įnešti lėšų į balansą.\n'
+            'Naudokite pagrindinį meniu darbui su botu:\n'
+            '🛍 Parduotuvė – naršykite kategorijas ir pasirinkite prekę.\n'
+            '   • Pasirinkite prekę ir patvirtinkite pirkimą.\n'
+            '👤 Profilis – jūsų balansas ir nupirktos prekės.\n'
+            '💸 Papildyti – pasirinkite mokėjimo būdą ir vykdykite instrukcijas.\n'
             '🌐 Kalba – pakeisti sąsajos kalbą.\n'
+            '🎁 Nupirktos prekės – matomos profilyje po pirkimo.\n'
             'Jei reikia pagalbos, susisiekite su {helper}.'
+        ),
+        'admin_help_info': (
+            'Admin pulto funkcijos:\n'
+            '🛠 Asistentų priskyrimas – valdykite asistentų paskyras.\n'
+            '📦 Peržiūrėti likučius – naršykite prekes ir trinkite likučius.\n'
+            '🏪 Parduotuvės valdymas – prekių ir kategorijų valdymas.\n'
+            '👥 Vartotojų valdymas – naudotojų balansai ir rolės.\n'
+            '📢 Pranešimų siuntimas – siųsti žinutes vartotojams.'
+        ),
+        'assistant_help_info': (
+            'Asistento pulto funkcijos:\n'
+            '🖼 Nuotraukų priskyrimas – pridėkite nuotraukas prie prekių.\n'
+            'Naudokite „Atgal į meniu“ norėdami grįžti.'
         ),
         'choose_language': 'Pasirinkite kalbą',
         'invoice_message': (


### PR DESCRIPTION
## Summary
- Ensure back-to-menu works from any state
- Expand help text and add admin-specific help screen
- Provide stock viewer for owners to browse and delete item stock

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b4c9dcf52c833280a533cc774819a1